### PR TITLE
add:增加对kylin-release文件的适配逻辑

### DIFF
--- a/host/host_linux.go
+++ b/host/host_linux.go
@@ -229,6 +229,12 @@ func PlatformInformationWithContext(ctx context.Context) (platform string, famil
 			version = getRedhatishVersion(contents)
 			platform = getRedhatishPlatform(contents)
 		}
+	} else if common.PathExists(common.HostEtcWithContext(ctx, "kylin-release")) {
+		contents, err := common.ReadLines(common.HostEtcWithContext(ctx, "kylin-release"))
+		if err == nil {
+			version = getRedhatishVersion(contents)
+			platform = getRedhatishPlatform(contents)
+		}
 	} else if common.PathExists(common.HostEtcWithContext(ctx, "redhat-release")) {
 		contents, err := common.ReadLines(common.HostEtcWithContext(ctx, "redhat-release"))
 		if err == nil {


### PR DESCRIPTION
kylin 系统存在 2种不同公司维护的版本。
其产生的 /etc/xxx-release 文件也不一致
一种是 kylin-release  一种是 neokylin-release