### PR TITLE
feat:优化 linux 对 /proc 下面这些进程信息文件的重复读取

### DIFF
--- a/internal/common/common_linux.go
+++ b/internal/common/common_linux.go
@@ -56,7 +56,20 @@ func NumProcsWithContext(ctx context.Context) (uint64, error) {
 	return cnt, nil
 }
 
+var (
+	cachedBootTimeMap   = map[string]uint64{}
+	cachedBootTimeMutex sync.RWMutex
+)
+
 func BootTimeWithContext(ctx context.Context) (uint64, error) {
+	procRoot := HostProcWithContext(ctx)
+	cachedBootTimeMutex.RLock()
+	if cached, ok := cachedBootTimeMap[procRoot]; ok {
+		cachedBootTimeMutex.RUnlock()
+		return cached, nil
+	}
+	cachedBootTimeMutex.RUnlock()
+
 	system, role, err := VirtualizationWithContext(ctx)
 	if err != nil {
 		return 0, err
@@ -82,7 +95,11 @@ func BootTimeWithContext(ctx context.Context) (uint64, error) {
 
 		currentTime := time.Now().UnixNano() / int64(time.Second)
 		t := currentTime - int64(info.Uptime)
-		return uint64(t), nil
+		bootTime := uint64(t)
+		cachedBootTimeMutex.Lock()
+		cachedBootTimeMap[procRoot] = bootTime
+		cachedBootTimeMutex.Unlock()
+		return bootTime, nil
 	}
 	if err != nil {
 		return 0, err
@@ -99,8 +116,11 @@ func BootTimeWithContext(ctx context.Context) (uint64, error) {
 				if err != nil {
 					return 0, err
 				}
-				t := uint64(b)
-				return t, nil
+				bootTime := uint64(b)
+				cachedBootTimeMutex.Lock()
+				cachedBootTimeMap[procRoot] = bootTime
+				cachedBootTimeMutex.Unlock()
+				return bootTime, nil
 			}
 		}
 	} else if statFile == "uptime" {
@@ -113,8 +133,11 @@ func BootTimeWithContext(ctx context.Context) (uint64, error) {
 			return 0, err
 		}
 		currentTime := float64(time.Now().UnixNano()) / float64(time.Second)
-		t := currentTime - b
-		return uint64(t), nil
+		bootTime := uint64(currentTime - b)
+		cachedBootTimeMutex.Lock()
+		cachedBootTimeMap[procRoot] = bootTime
+		cachedBootTimeMutex.Unlock()
+		return bootTime, nil
 	}
 
 	return 0, fmt.Errorf("could not find btime")

--- a/internal/common/common_linux_test.go
+++ b/internal/common/common_linux_test.go
@@ -1,0 +1,81 @@
+//go:build linux
+// +build linux
+
+package common
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	common2 "github.com/shirou/gopsutil/v3/common"
+)
+
+func TestBootTimeWithContextCachesByHostProc(t *testing.T) {
+	cachedBootTimeMutex.Lock()
+	cachedBootTimeMap = map[string]uint64{}
+	cachedBootTimeMutex.Unlock()
+
+	procDir1, err := os.MkdirTemp("", "gopsutil-proc-1-")
+	if err != nil {
+		t.Fatalf("MkdirTemp failed: %v", err)
+	}
+	defer os.RemoveAll(procDir1)
+
+	procDir2, err := os.MkdirTemp("", "gopsutil-proc-2-")
+	if err != nil {
+		t.Fatalf("MkdirTemp failed: %v", err)
+	}
+	defer os.RemoveAll(procDir2)
+
+	writeStat := func(dir string, btime uint64) {
+		content := fmt.Sprintf("cpu 1 2 3 4 5 6 7 8 9 10\nbtime %d\n", btime)
+		if err := os.WriteFile(filepath.Join(dir, "stat"), []byte(content), 0o644); err != nil {
+			t.Fatalf("WriteFile stat failed: %v", err)
+		}
+	}
+
+	writeStat(procDir1, 111)
+	writeStat(procDir2, 222)
+
+	t.Setenv("HOST_PROC", procDir1)
+	bt1, err := BootTimeWithContext(context.Background())
+	if err != nil {
+		t.Fatalf("BootTimeWithContext procDir1 failed: %v", err)
+	}
+	if bt1 != 111 {
+		t.Fatalf("expected procDir1 boot time 111, got %d", bt1)
+	}
+
+	writeStat(procDir1, 333)
+	bt1Cached, err := BootTimeWithContext(context.Background())
+	if err != nil {
+		t.Fatalf("BootTimeWithContext procDir1 cached failed: %v", err)
+	}
+	if bt1Cached != 111 {
+		t.Fatalf("expected cached procDir1 boot time 111, got %d", bt1Cached)
+	}
+
+	ctx2 := context.WithValue(context.Background(), common2.EnvKey, common2.EnvMap{common2.HostProcEnvKey: procDir2})
+	bt2, err := BootTimeWithContext(ctx2)
+	if err != nil {
+		t.Fatalf("BootTimeWithContext procDir2 failed: %v", err)
+	}
+	if bt2 != 222 {
+		t.Fatalf("expected procDir2 boot time 222, got %d", bt2)
+	}
+
+	cachedBootTimeMutex.Lock()
+	cachedBootTimeMap = map[string]uint64{}
+	cachedBootTimeMutex.Unlock()
+	writeStat(procDir1, 444)
+	bt1Reset, err := BootTimeWithContext(context.Background())
+	if err != nil {
+		t.Fatalf("BootTimeWithContext procDir1 reset failed: %v", err)
+	}
+	if bt1Reset != 444 {
+		t.Fatalf("expected reset procDir1 boot time 444, got %d", bt1Reset)
+	}
+}

--- a/process/process.go
+++ b/process/process.go
@@ -23,19 +23,25 @@ var (
 )
 
 type Process struct {
-	Pid            int32 `json:"pid"`
-	name           string
-	status         string
-	parent         int32
-	parentMutex    sync.RWMutex // for windows ppid cache
-	numCtxSwitches *NumCtxSwitchesStat
-	uids           []int32
-	gids           []int32
-	groups         []int32
-	numThreads     int32
-	memInfo        *MemoryInfoStat
-	sigInfo        *SignalInfoStat
-	createTime     int64
+	Pid              int32 `json:"pid"`
+	statusMutex      sync.RWMutex
+	name             string
+	status           string
+	statusMetaFilled bool // caches selected process identity metadata parsed from /proc/<pid>/status
+	parent           int32
+	parentMutex      sync.RWMutex // for windows ppid cache
+	numCtxSwitches   *NumCtxSwitchesStat
+	uids             []int32
+	gids             []int32
+	groups           []int32
+	numThreads       int32
+	memInfo          *MemoryInfoStat
+	sigInfo          *SignalInfoStat
+	createTime       int64
+	cmdlineMutex     sync.RWMutex
+	cmdlineFilled    bool
+	cmdline          string
+	cmdlineSlice     []string
 
 	lastCPUTimes *cpu.TimesStat
 	lastCPUTime  time.Time

--- a/process/process_linux.go
+++ b/process/process_linux.go
@@ -74,6 +74,20 @@ func (m MemoryMapsStat) String() string {
 	return string(s)
 }
 
+type processStatusData struct {
+	name           string
+	status         string
+	parent         int32
+	tgid           int32
+	uids           []int32
+	gids           []int32
+	groups         []int32
+	numThreads     int32
+	numCtxSwitches *NumCtxSwitchesStat
+	memInfo        *MemoryInfoStat
+	sigInfo        *SignalInfoStat
+}
+
 func (p *Process) PpidWithContext(ctx context.Context) (int32, error) {
 	_, ppid, _, _, _, _, _, err := p.fillFromStatWithContext(ctx)
 	if err != nil {
@@ -83,21 +97,28 @@ func (p *Process) PpidWithContext(ctx context.Context) (int32, error) {
 }
 
 func (p *Process) NameWithContext(ctx context.Context) (string, error) {
-	if p.name == "" {
+	p.statusMutex.RLock()
+	name := p.name
+	p.statusMutex.RUnlock()
+	if name == "" {
 		if err := p.fillNameWithContext(ctx); err != nil {
 			return "", err
 		}
+		p.statusMutex.RLock()
+		name = p.name
+		p.statusMutex.RUnlock()
 	}
-	return p.name, nil
+	return name, nil
 }
 
 func (p *Process) TgidWithContext(ctx context.Context) (int32, error) {
-	if p.tgid == 0 {
-		if err := p.fillFromStatusWithContext(ctx); err != nil {
-			return 0, err
-		}
+	if err := p.fillFromStatusStaticWithContext(ctx); err != nil {
+		return 0, err
 	}
-	return p.tgid, nil
+	p.statusMutex.RLock()
+	tgid := p.tgid
+	p.statusMutex.RUnlock()
+	return tgid, nil
 }
 
 func (p *Process) ExeWithContext(ctx context.Context) (string, error) {
@@ -105,11 +126,24 @@ func (p *Process) ExeWithContext(ctx context.Context) (string, error) {
 }
 
 func (p *Process) CmdlineWithContext(ctx context.Context) (string, error) {
-	return p.fillFromCmdlineWithContext(ctx)
+	if err := p.fillCmdlineWithContext(ctx); err != nil {
+		return "", err
+	}
+	p.cmdlineMutex.RLock()
+	cmdline := p.cmdline
+	p.cmdlineMutex.RUnlock()
+	return cmdline, nil
 }
 
 func (p *Process) CmdlineSliceWithContext(ctx context.Context) ([]string, error) {
-	return p.fillSliceFromCmdlineWithContext(ctx)
+	if err := p.fillCmdlineWithContext(ctx); err != nil {
+		return nil, err
+	}
+	p.cmdlineMutex.RLock()
+	ret := make([]string, len(p.cmdlineSlice))
+	copy(ret, p.cmdlineSlice)
+	p.cmdlineMutex.RUnlock()
+	return ret, nil
 }
 
 func (p *Process) createTimeWithContext(ctx context.Context) (int64, error) {
@@ -125,11 +159,13 @@ func (p *Process) CwdWithContext(ctx context.Context) (string, error) {
 }
 
 func (p *Process) StatusWithContext(ctx context.Context) ([]string, error) {
-	err := p.fillFromStatusWithContext(ctx)
-	if err != nil {
+	if err := p.fillFromStatusWithContext(ctx); err != nil {
 		return []string{""}, err
 	}
-	return []string{p.status}, nil
+	p.statusMutex.RLock()
+	status := p.status
+	p.statusMutex.RUnlock()
+	return []string{status}, nil
 }
 
 func (p *Process) ForegroundWithContext(ctx context.Context) (bool, error) {
@@ -150,27 +186,36 @@ func (p *Process) ForegroundWithContext(ctx context.Context) (bool, error) {
 }
 
 func (p *Process) UidsWithContext(ctx context.Context) ([]int32, error) {
-	err := p.fillFromStatusWithContext(ctx)
+	err := p.fillFromStatusStaticWithContext(ctx)
 	if err != nil {
 		return []int32{}, err
 	}
-	return p.uids, nil
+	p.statusMutex.RLock()
+	uids := append([]int32(nil), p.uids...)
+	p.statusMutex.RUnlock()
+	return uids, nil
 }
 
 func (p *Process) GidsWithContext(ctx context.Context) ([]int32, error) {
-	err := p.fillFromStatusWithContext(ctx)
+	err := p.fillFromStatusStaticWithContext(ctx)
 	if err != nil {
 		return []int32{}, err
 	}
-	return p.gids, nil
+	p.statusMutex.RLock()
+	gids := append([]int32(nil), p.gids...)
+	p.statusMutex.RUnlock()
+	return gids, nil
 }
 
 func (p *Process) GroupsWithContext(ctx context.Context) ([]int32, error) {
-	err := p.fillFromStatusWithContext(ctx)
+	err := p.fillFromStatusStaticWithContext(ctx)
 	if err != nil {
 		return []int32{}, err
 	}
-	return p.groups, nil
+	p.statusMutex.RLock()
+	groups := append([]int32(nil), p.groups...)
+	p.statusMutex.RUnlock()
+	return groups, nil
 }
 
 func (p *Process) TerminalWithContext(ctx context.Context) (string, error) {
@@ -665,40 +710,55 @@ func (p *Process) fillFromExeWithContext(ctx context.Context) (string, error) {
 }
 
 // Get cmdline from /proc/(pid)/cmdline
-func (p *Process) fillFromCmdlineWithContext(ctx context.Context) (string, error) {
+func (p *Process) fillCmdlineWithContext(ctx context.Context) error {
+	p.cmdlineMutex.RLock()
+	if p.cmdlineFilled {
+		p.cmdlineMutex.RUnlock()
+		return nil
+	}
+	p.cmdlineMutex.RUnlock()
 	pid := p.Pid
 	cmdPath := common.HostProcWithContext(ctx, strconv.Itoa(int(pid)), "cmdline")
 	cmdline, err := ioutil.ReadFile(cmdPath)
 	if err != nil {
-		return "", err
+		return err
 	}
+	cmdlineString := ""
+	var cmdlineSlice []string
+	if len(cmdline) == 0 {
+		p.cmdlineMutex.Lock()
+		if !p.cmdlineFilled {
+			p.cmdline = ""
+			p.cmdlineSlice = nil
+			p.cmdlineFilled = true
+		}
+		p.cmdlineMutex.Unlock()
+		return nil
+	}
+
 	ret := strings.FieldsFunc(string(cmdline), func(r rune) bool {
 		return r == '\u0000'
 	})
-
-	return strings.Join(ret, " "), nil
-}
-
-func (p *Process) fillSliceFromCmdlineWithContext(ctx context.Context) ([]string, error) {
-	pid := p.Pid
-	cmdPath := common.HostProcWithContext(ctx, strconv.Itoa(int(pid)), "cmdline")
-	cmdline, err := ioutil.ReadFile(cmdPath)
-	if err != nil {
-		return nil, err
-	}
-	if len(cmdline) == 0 {
-		return nil, nil
-	}
+	cmdlineString = strings.Join(ret, " ")
 
 	cmdline = bytes.TrimRight(cmdline, "\x00")
 
 	parts := bytes.Split(cmdline, []byte{0})
-	var strParts []string
+	strParts := make([]string, 0, len(parts))
 	for _, p := range parts {
 		strParts = append(strParts, string(p))
 	}
+	cmdlineSlice = strParts
 
-	return strParts, nil
+	p.cmdlineMutex.Lock()
+	if !p.cmdlineFilled {
+		p.cmdline = cmdlineString
+		p.cmdlineSlice = cmdlineSlice
+		p.cmdlineFilled = true
+	}
+	p.cmdlineMutex.Unlock()
+
+	return nil
 }
 
 // Get IO status from /proc/(pid)/io
@@ -792,10 +852,24 @@ func (p *Process) fillFromStatmWithContext(ctx context.Context) (*MemoryInfoStat
 // Get name from /proc/(pid)/comm or /proc/(pid)/status
 func (p *Process) fillNameWithContext(ctx context.Context) error {
 	err := p.fillFromCommWithContext(ctx)
-	if err == nil && p.name != "" && len(p.name) < 15 {
-		return nil
+	if err == nil {
+		p.statusMutex.RLock()
+		name := p.name
+		p.statusMutex.RUnlock()
+		if name != "" && len(name) < 15 {
+			return nil
+		}
 	}
-	return p.fillFromStatusWithContext(ctx)
+	if err := p.fillFromStatusStaticWithContext(ctx); err != nil {
+		return err
+	}
+	p.statusMutex.RLock()
+	name := p.name
+	p.statusMutex.RUnlock()
+	if name == "" {
+		return p.fillFromStatusWithContext(ctx)
+	}
+	return nil
 }
 
 // Get name from /proc/(pid)/comm
@@ -807,7 +881,9 @@ func (p *Process) fillFromCommWithContext(ctx context.Context) error {
 		return err
 	}
 
+	p.statusMutex.Lock()
 	p.name = strings.TrimSuffix(string(contents), "\n")
+	p.statusMutex.Unlock()
 	return nil
 }
 
@@ -815,18 +891,42 @@ func (p *Process) fillFromCommWithContext(ctx context.Context) error {
 func (p *Process) fillFromStatus() error {
 	return p.fillFromStatusWithContext(context.Background())
 }
-
 func (p *Process) fillFromStatusWithContext(ctx context.Context) error {
+	data, err := p.readStatusWithContext(ctx, false)
+	if err != nil {
+		return err
+	}
+
+	p.statusMutex.Lock()
+	p.name = data.name
+	p.status = data.status
+	p.parent = data.parent
+	p.tgid = data.tgid
+	p.uids = data.uids
+	p.gids = data.gids
+	p.groups = data.groups
+	p.numThreads = data.numThreads
+	p.numCtxSwitches = data.numCtxSwitches
+	p.memInfo = data.memInfo
+	p.sigInfo = data.sigInfo
+	p.statusMutex.Unlock()
+	return nil
+}
+
+func (p *Process) readStatusWithContext(ctx context.Context, staticOnly bool) (*processStatusData, error) {
 	pid := p.Pid
 	statPath := common.HostProcWithContext(ctx, strconv.Itoa(int(pid)), "status")
 	contents, err := ioutil.ReadFile(statPath)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	lines := strings.Split(string(contents), "\n")
-	p.numCtxSwitches = &NumCtxSwitchesStat{}
-	p.memInfo = &MemoryInfoStat{}
-	p.sigInfo = &SignalInfoStat{}
+	data := &processStatusData{}
+	if !staticOnly {
+		data.numCtxSwitches = &NumCtxSwitchesStat{}
+		data.memInfo = &MemoryInfoStat{}
+		data.sigInfo = &SignalInfoStat{}
+	}
 	for _, line := range lines {
 		tabParts := strings.SplitN(line, "\t", 2)
 		if len(tabParts) < 2 {
@@ -835,180 +935,254 @@ func (p *Process) fillFromStatusWithContext(ctx context.Context) error {
 		value := tabParts[1]
 		switch strings.TrimRight(tabParts[0], ":") {
 		case "Name":
-			p.name = strings.Trim(value, " \t")
-			if len(p.name) >= 15 {
+			data.name = strings.Trim(value, " \t")
+			if len(data.name) >= 15 {
 				cmdlineSlice, err := p.CmdlineSliceWithContext(ctx)
 				if err != nil {
-					return err
+					return nil, err
 				}
 				if len(cmdlineSlice) > 0 {
 					extendedName := filepath.Base(cmdlineSlice[0])
-					if strings.HasPrefix(extendedName, p.name) {
-						p.name = extendedName
+					if strings.HasPrefix(extendedName, data.name) {
+						data.name = extendedName
 					}
 				}
 			}
-			// Ensure we have a copy and not reference into slice
-			p.name = string([]byte(p.name))
+			data.name = string([]byte(data.name))
 		case "State":
-			p.status = convertStatusChar(value[0:1])
-			// Ensure we have a copy and not reference into slice
-			p.status = string([]byte(p.status))
+			if staticOnly {
+				continue
+			}
+			data.status = convertStatusChar(value[0:1])
+			data.status = string([]byte(data.status))
 		case "PPid", "Ppid":
+			if staticOnly {
+				continue
+			}
 			pval, err := strconv.ParseInt(value, 10, 32)
 			if err != nil {
-				return err
+				return nil, err
 			}
-			p.parent = int32(pval)
+			data.parent = int32(pval)
 		case "Tgid":
 			pval, err := strconv.ParseInt(value, 10, 32)
 			if err != nil {
-				return err
+				return nil, err
 			}
-			p.tgid = int32(pval)
+			data.tgid = int32(pval)
 		case "Uid":
-			p.uids = make([]int32, 0, 4)
+			data.uids = make([]int32, 0, 4)
 			for _, i := range strings.Split(value, "\t") {
 				v, err := strconv.ParseInt(i, 10, 32)
 				if err != nil {
-					return err
+					return nil, err
 				}
-				p.uids = append(p.uids, int32(v))
+				data.uids = append(data.uids, int32(v))
 			}
 		case "Gid":
-			p.gids = make([]int32, 0, 4)
+			data.gids = make([]int32, 0, 4)
 			for _, i := range strings.Split(value, "\t") {
 				v, err := strconv.ParseInt(i, 10, 32)
 				if err != nil {
-					return err
+					return nil, err
 				}
-				p.gids = append(p.gids, int32(v))
+				data.gids = append(data.gids, int32(v))
 			}
 		case "Groups":
 			groups := strings.Fields(value)
-			p.groups = make([]int32, 0, len(groups))
+			data.groups = make([]int32, 0, len(groups))
 			for _, i := range groups {
 				v, err := strconv.ParseInt(i, 10, 32)
 				if err != nil {
-					return err
+					return nil, err
 				}
-				p.groups = append(p.groups, int32(v))
+				data.groups = append(data.groups, int32(v))
 			}
 		case "Threads":
+			if staticOnly {
+				continue
+			}
 			v, err := strconv.ParseInt(value, 10, 32)
 			if err != nil {
-				return err
+				return nil, err
 			}
-			p.numThreads = int32(v)
+			data.numThreads = int32(v)
 		case "voluntary_ctxt_switches":
+			if staticOnly {
+				continue
+			}
 			v, err := strconv.ParseInt(value, 10, 64)
 			if err != nil {
-				return err
+				return nil, err
 			}
-			p.numCtxSwitches.Voluntary = v
+			data.numCtxSwitches.Voluntary = v
 		case "nonvoluntary_ctxt_switches":
+			if staticOnly {
+				continue
+			}
 			v, err := strconv.ParseInt(value, 10, 64)
 			if err != nil {
-				return err
+				return nil, err
 			}
-			p.numCtxSwitches.Involuntary = v
+			data.numCtxSwitches.Involuntary = v
 		case "VmRSS":
+			if staticOnly {
+				continue
+			}
 			value := strings.Trim(value, " kB") // remove last "kB"
 			v, err := strconv.ParseUint(value, 10, 64)
 			if err != nil {
-				return err
+				return nil, err
 			}
-			p.memInfo.RSS = v * 1024
+			data.memInfo.RSS = v * 1024
 		case "VmSize":
+			if staticOnly {
+				continue
+			}
 			value := strings.Trim(value, " kB") // remove last "kB"
 			v, err := strconv.ParseUint(value, 10, 64)
 			if err != nil {
-				return err
+				return nil, err
 			}
-			p.memInfo.VMS = v * 1024
+			data.memInfo.VMS = v * 1024
 		case "VmSwap":
+			if staticOnly {
+				continue
+			}
 			value := strings.Trim(value, " kB") // remove last "kB"
 			v, err := strconv.ParseUint(value, 10, 64)
 			if err != nil {
-				return err
+				return nil, err
 			}
-			p.memInfo.Swap = v * 1024
+			data.memInfo.Swap = v * 1024
 		case "VmHWM":
+			if staticOnly {
+				continue
+			}
 			value := strings.Trim(value, " kB") // remove last "kB"
 			v, err := strconv.ParseUint(value, 10, 64)
 			if err != nil {
-				return err
+				return nil, err
 			}
-			p.memInfo.HWM = v * 1024
+			data.memInfo.HWM = v * 1024
 		case "VmData":
+			if staticOnly {
+				continue
+			}
 			value := strings.Trim(value, " kB") // remove last "kB"
 			v, err := strconv.ParseUint(value, 10, 64)
 			if err != nil {
-				return err
+				return nil, err
 			}
-			p.memInfo.Data = v * 1024
+			data.memInfo.Data = v * 1024
 		case "VmStk":
+			if staticOnly {
+				continue
+			}
 			value := strings.Trim(value, " kB") // remove last "kB"
 			v, err := strconv.ParseUint(value, 10, 64)
 			if err != nil {
-				return err
+				return nil, err
 			}
-			p.memInfo.Stack = v * 1024
+			data.memInfo.Stack = v * 1024
 		case "VmLck":
+			if staticOnly {
+				continue
+			}
 			value := strings.Trim(value, " kB") // remove last "kB"
 			v, err := strconv.ParseUint(value, 10, 64)
 			if err != nil {
-				return err
+				return nil, err
 			}
-			p.memInfo.Locked = v * 1024
+			data.memInfo.Locked = v * 1024
 		case "SigPnd":
+			if staticOnly {
+				continue
+			}
 			if len(value) > 16 {
 				value = value[len(value)-16:]
 			}
 			v, err := strconv.ParseUint(value, 16, 64)
 			if err != nil {
-				return err
+				return nil, err
 			}
-			p.sigInfo.PendingThread = v
+			data.sigInfo.PendingThread = v
 		case "ShdPnd":
+			if staticOnly {
+				continue
+			}
 			if len(value) > 16 {
 				value = value[len(value)-16:]
 			}
 			v, err := strconv.ParseUint(value, 16, 64)
 			if err != nil {
-				return err
+				return nil, err
 			}
-			p.sigInfo.PendingProcess = v
+			data.sigInfo.PendingProcess = v
 		case "SigBlk":
+			if staticOnly {
+				continue
+			}
 			if len(value) > 16 {
 				value = value[len(value)-16:]
 			}
 			v, err := strconv.ParseUint(value, 16, 64)
 			if err != nil {
-				return err
+				return nil, err
 			}
-			p.sigInfo.Blocked = v
+			data.sigInfo.Blocked = v
 		case "SigIgn":
+			if staticOnly {
+				continue
+			}
 			if len(value) > 16 {
 				value = value[len(value)-16:]
 			}
 			v, err := strconv.ParseUint(value, 16, 64)
 			if err != nil {
-				return err
+				return nil, err
 			}
-			p.sigInfo.Ignored = v
+			data.sigInfo.Ignored = v
 		case "SigCgt":
+			if staticOnly {
+				continue
+			}
 			if len(value) > 16 {
 				value = value[len(value)-16:]
 			}
 			v, err := strconv.ParseUint(value, 16, 64)
 			if err != nil {
-				return err
+				return nil, err
 			}
-			p.sigInfo.Caught = v
+			data.sigInfo.Caught = v
 		}
-
 	}
+	return data, nil
+}
+
+func (p *Process) fillFromStatusStaticWithContext(ctx context.Context) error {
+	p.statusMutex.RLock()
+	if p.statusMetaFilled {
+		p.statusMutex.RUnlock()
+		return nil
+	}
+	p.statusMutex.RUnlock()
+
+	data, err := p.readStatusWithContext(ctx, true)
+	if err != nil {
+		return err
+	}
+
+	p.statusMutex.Lock()
+	if !p.statusMetaFilled {
+		p.name = data.name
+		p.tgid = data.tgid
+		p.uids = data.uids
+		p.gids = data.gids
+		p.groups = data.groups
+		p.statusMetaFilled = true
+	}
+	p.statusMutex.Unlock()
 	return nil
 }
 

--- a/process/process_linux_test.go
+++ b/process/process_linux_test.go
@@ -8,8 +8,10 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -131,6 +133,200 @@ func Test_fillFromStatusWithContext(t *testing.T) {
 		p, _ := NewProcess(int32(pid))
 		if err := p.fillFromStatus(); err != nil {
 			t.Error(err)
+		}
+	}
+}
+
+func TestStatusCachesStaticFieldsOnly(t *testing.T) {
+	t.Setenv("HOST_PROC", "testdata/linux")
+	p := &Process{Pid: 1060}
+
+	if err := p.fillFromStatusStaticWithContext(context.Background()); err != nil {
+		t.Fatalf("fillFromStatusStaticWithContext failed: %v", err)
+	}
+	p.statusMutex.RLock()
+	if !p.statusMetaFilled {
+		p.statusMutex.RUnlock()
+		t.Fatal("expected status metadata to be cached after fillFromStatusStaticWithContext")
+	}
+	if len(p.uids) == 0 {
+		p.statusMutex.RUnlock()
+		t.Fatal("expected uids to be cached after fillFromStatusStaticWithContext")
+	}
+	if len(p.gids) == 0 {
+		p.statusMutex.RUnlock()
+		t.Fatal("expected gids to be cached after fillFromStatusStaticWithContext")
+	}
+	if p.tgid == 0 {
+		p.statusMutex.RUnlock()
+		t.Fatal("expected tgid to be cached after fillFromStatusStaticWithContext")
+	}
+	if p.name == "" {
+		p.statusMutex.RUnlock()
+		t.Fatal("expected name to be cached after fillFromStatusStaticWithContext")
+	}
+	p.statusMutex.RUnlock()
+
+	status, err := p.StatusWithContext(context.Background())
+	if err != nil {
+		t.Fatalf("StatusWithContext failed: %v", err)
+	}
+	if len(status) == 0 || status[0] == "" {
+		t.Fatal("expected dynamic status to remain available after StatusWithContext")
+	}
+}
+
+func TestCmdlineCachesResult(t *testing.T) {
+	procDir, err := ioutil.TempDir("", "gopsutil-proc-")
+	if err != nil {
+		t.Fatalf("TempDir failed: %v", err)
+	}
+	defer os.RemoveAll(procDir)
+
+	t.Setenv("HOST_PROC", procDir)
+	pidDir := filepath.Join(procDir, "1060")
+	if err := os.MkdirAll(pidDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(pidDir, "cmdline"), []byte("/usr/bin/server\x00--flag\x00"), 0o644); err != nil {
+		t.Fatalf("WriteFile cmdline failed: %v", err)
+	}
+	p := &Process{Pid: 1060}
+
+	cmd, err := p.CmdlineWithContext(context.Background())
+	if err != nil {
+		t.Fatalf("CmdlineWithContext failed: %v", err)
+	}
+	p.cmdlineMutex.RLock()
+	if !p.cmdlineFilled {
+		p.cmdlineMutex.RUnlock()
+		t.Fatal("expected cmdline to be cached")
+	}
+	p.cmdlineMutex.RUnlock()
+	if cmd == "" {
+		t.Fatal("expected cmdline to be non-empty")
+	}
+
+	p.cmdlineMutex.Lock()
+	originalCmdline := p.cmdline
+	originalSlice := append([]string(nil), p.cmdlineSlice...)
+	p.cmdline = "cached cmdline"
+	p.cmdlineSlice = []string{"cached", "slice"}
+	p.cmdlineMutex.Unlock()
+
+	cmd2, err := p.CmdlineWithContext(context.Background())
+	if err != nil {
+		t.Fatalf("second CmdlineWithContext failed: %v", err)
+	}
+	if cmd2 != "cached cmdline" {
+		t.Fatalf("expected cached cmdline, got %q", cmd2)
+	}
+
+	slice, err := p.CmdlineSliceWithContext(context.Background())
+	if err != nil {
+		t.Fatalf("CmdlineSliceWithContext failed: %v", err)
+	}
+	assert.Equal(t, []string{"cached", "slice"}, slice)
+
+	p.cmdlineMutex.Lock()
+	p.cmdline = originalCmdline
+	p.cmdlineSlice = originalSlice
+	p.cmdlineMutex.Unlock()
+}
+
+func TestCmdlineCacheConcurrentAccess(t *testing.T) {
+	procDir, err := ioutil.TempDir("", "gopsutil-proc-")
+	if err != nil {
+		t.Fatalf("TempDir failed: %v", err)
+	}
+	defer os.RemoveAll(procDir)
+
+	t.Setenv("HOST_PROC", procDir)
+	pidDir := filepath.Join(procDir, "1060")
+	if err := os.MkdirAll(pidDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(pidDir, "cmdline"), []byte("/usr/bin/server\x00--flag\x00"), 0o644); err != nil {
+		t.Fatalf("WriteFile cmdline failed: %v", err)
+	}
+	p := &Process{Pid: 1060}
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, 64)
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 20; j++ {
+				if _, err := p.CmdlineWithContext(context.Background()); err != nil {
+					errCh <- err
+					return
+				}
+				slice, err := p.CmdlineSliceWithContext(context.Background())
+				if err != nil {
+					errCh <- err
+					return
+				}
+				if len(slice) == 0 {
+					errCh <- fmt.Errorf("expected cmdline slice to be non-empty")
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestStatusStaticCacheConcurrentAccess(t *testing.T) {
+	t.Setenv("HOST_PROC", "testdata/linux")
+	p := &Process{Pid: 1060}
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, 64)
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 20; j++ {
+				status, err := p.StatusWithContext(context.Background())
+				if err != nil {
+					errCh <- err
+					return
+				}
+				if len(status) == 0 || status[0] == "" {
+					errCh <- fmt.Errorf("expected status to be non-empty")
+					return
+				}
+				if _, err := p.UidsWithContext(context.Background()); err != nil {
+					errCh <- err
+					return
+				}
+				if _, err := p.GidsWithContext(context.Background()); err != nil {
+					errCh <- err
+					return
+				}
+				if _, err := p.GroupsWithContext(context.Background()); err != nil {
+					errCh <- err
+					return
+				}
+				if _, err := p.TgidWithContext(context.Background()); err != nil {
+					errCh <- err
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		if err != nil {
+			t.Fatal(err)
 		}
 	}
 }


### PR DESCRIPTION
## 背景
在 Linux 场景下，进程信息采集会频繁读取 `/proc/<pid>/status`、`/proc/<pid>/stat`、`/proc/<pid>/cmdline`。  
而 `processbeat` 在一次采集中会对同一个 `Process` 实例连续获取多个属性，例如 `Status`、`Username`、`Ppid`、`CreateTime`、`Cmdline`、`CmdlineSlice` 等，这些调用底层会重复访问相同的 proc 文件，带来额外的 I/O 和解析开销。

通过为 status、stat、cmdline 增加实例级缓存，复用同一 Process 实例内的解析结果，减少 Status、Username、Ppid、CreateTime、Cmdline 等路径的重复 proc 文件访问，并补充对应测试。