### PR TITLE
ci: fix deprecated cache action in test workflows

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -12,7 +12,7 @@ jobs:
       - id: versions
         run: |
           versions=$(curl -s 'https://go.dev/dl/?mode=json' | jq -c 'map(.version[2:])')
-          echo "::set-output name=value::${versions}"
+          echo "value=${versions}" >> "$GITHUB_OUTPUT"
   build_test_v3:
     needs: go-versions
     strategy:
@@ -29,10 +29,10 @@ jobs:
       uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
     - id: cache-paths
       run: |
-        echo "::set-output name=cache::$(go env GOCACHE)"
-        echo "::set-output name=mod-cache::$(go env GOMODCACHE)"
+        echo "cache=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
+        echo "mod-cache=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
     - name: Cache go modules
-      uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: |
           ${{ steps.cache-paths.outputs.cache }}

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -28,6 +28,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
     - id: cache-paths
+      shell: bash
       run: |
         echo "cache=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
         echo "mod-cache=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
     - id: go-env
+      shell: bash
       run: |
         echo "cache=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
         echo "mod-cache=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       - id: versions
         run: |
           versions=$(curl -s 'https://go.dev/dl/?mode=json' | jq -c 'map(.version[2:])')
-          echo "::set-output name=value::${versions}"
+          echo "value=${versions}" >> "$GITHUB_OUTPUT"
   test_v3_module:
     needs: go-versions
     strategy:
@@ -30,10 +30,10 @@ jobs:
       uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
     - id: go-env
       run: |
-        echo "::set-output name=cache::$(go env GOCACHE)"
-        echo "::set-output name=mod-cache::$(go env GOMODCACHE)"
+        echo "cache=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
+        echo "mod-cache=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
     - name: Cache go modules
-      uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: |
           ${{ steps.go-env.outputs.cache }}


### PR DESCRIPTION
## Summary
- replace the deprecated `actions/cache` pin in `.github/workflows/test.yml` and `.github/workflows/build_test.yml`
- switch the same workflows from `::set-output` to `$GITHUB_OUTPUT` while touching them

## Why
The current `Build Test` and `Test` jobs fail during setup because GitHub now blocks the old `actions/cache` revision before any build or test step can run. This keeps the workflow fix isolated from feature PRs like #16.

## Verification
- `/tmp/actionlint-bin/actionlint -ignore 'label ".*" is unknown' .github/workflows/test.yml .github/workflows/build_test.yml`

## Notes
- The ignored `runner-label` warnings are pre-existing because the workflow still lists older hosted runner labels; this PR does not expand that scope.
