### PR TITLE
ci: fix deprecated cache action in test workflows

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -12,7 +12,7 @@ jobs:
       - id: versions
         run: |
           versions=$(curl -s 'https://go.dev/dl/?mode=json' | jq -c 'map(.version[2:])')
-          echo "::set-output name=value::${versions}"
+          echo "value=${versions}" >> "$GITHUB_OUTPUT"
   build_test_v3:
     needs: go-versions
     strategy:
@@ -28,11 +28,12 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
     - id: cache-paths
+      shell: bash
       run: |
-        echo "::set-output name=cache::$(go env GOCACHE)"
-        echo "::set-output name=mod-cache::$(go env GOMODCACHE)"
+        echo "cache=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
+        echo "mod-cache=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
     - name: Cache go modules
-      uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: |
           ${{ steps.cache-paths.outputs.cache }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       - id: versions
         run: |
           versions=$(curl -s 'https://go.dev/dl/?mode=json' | jq -c 'map(.version[2:])')
-          echo "::set-output name=value::${versions}"
+          echo "value=${versions}" >> "$GITHUB_OUTPUT"
   test_v3_module:
     needs: go-versions
     strategy:
@@ -29,11 +29,12 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
     - id: go-env
+      shell: bash
       run: |
-        echo "::set-output name=cache::$(go env GOCACHE)"
-        echo "::set-output name=mod-cache::$(go env GOMODCACHE)"
+        echo "cache=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
+        echo "mod-cache=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
     - name: Cache go modules
-      uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: |
           ${{ steps.go-env.outputs.cache }}


### PR DESCRIPTION
## Summary
- replace the deprecated `actions/cache` pin in `.github/workflows/test.yml` and `.github/workflows/build_test.yml`
- switch the same workflows from `::set-output` to `$GITHUB_OUTPUT`
- force the cache-output steps to run with `bash` so Windows jobs also populate the cache paths correctly

## Why
`Build Test` and `Test` were failing during setup because GitHub now blocks the old `actions/cache` revision. After updating the action, Windows jobs also needed an explicit `bash` shell for the `$GITHUB_OUTPUT` writes; otherwise `Cache go modules` saw an empty path and failed before tests even started.

## Verification
- `/tmp/actionlint-bin/actionlint -ignore 'label ".*" is unknown' .github/workflows/test.yml .github/workflows/build_test.yml`
- observed on PR checks: `build_test_v3` resumed running and Windows jobs passed the cache setup step instead of failing with `Path Validation Error`

## Notes
- Remaining `lint` and some `go test ./...` failures are repository baseline issues, not introduced by this workflow patch.
