### PR TITLE
test: fix newly introduced lint issues in linux cache tests

### DIFF
--- a/internal/common/common_linux_test.go
+++ b/internal/common/common_linux_test.go
@@ -32,7 +32,7 @@ func TestBootTimeWithContextCachesByHostProc(t *testing.T) {
 
 	writeStat := func(dir string, btime uint64) {
 		content := fmt.Sprintf("cpu 1 2 3 4 5 6 7 8 9 10\nbtime %d\n", btime)
-		if err := os.WriteFile(filepath.Join(dir, "stat"), []byte(content), 0o644); err != nil {
+		if err := os.WriteFile(filepath.Join(dir, "stat"), []byte(content), 0o600); err != nil {
 			t.Fatalf("WriteFile stat failed: %v", err)
 		}
 	}

--- a/process/process_linux_test.go
+++ b/process/process_linux_test.go
@@ -188,7 +188,7 @@ func TestCmdlineCachesResult(t *testing.T) {
 	if err := os.MkdirAll(pidDir, 0o755); err != nil {
 		t.Fatalf("MkdirAll failed: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(pidDir, "cmdline"), []byte("/usr/bin/server\x00--flag\x00"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(pidDir, "cmdline"), []byte("/usr/bin/server\x00--flag\x00"), 0o600); err != nil {
 		t.Fatalf("WriteFile cmdline failed: %v", err)
 	}
 	p := &Process{Pid: 1060}
@@ -246,7 +246,7 @@ func TestCmdlineCacheConcurrentAccess(t *testing.T) {
 	if err := os.MkdirAll(pidDir, 0o755); err != nil {
 		t.Fatalf("MkdirAll failed: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(pidDir, "cmdline"), []byte("/usr/bin/server\x00--flag\x00"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(pidDir, "cmdline"), []byte("/usr/bin/server\x00--flag\x00"), 0o600); err != nil {
 		t.Fatalf("WriteFile cmdline failed: %v", err)
 	}
 	p := &Process{Pid: 1060}


### PR DESCRIPTION
## Summary
- tighten temporary test file permissions to satisfy `gosec G306`
- keep the change scoped to the new linux cache tests from PR #16

## Verification
- `/tmp/golangci-bin/golangci-lint run --new-from-rev=HEAD ./internal/common/... ./process/...`

This is the fork-based follow-up on top of the current PR #16 head.
